### PR TITLE
[Bug] : Enable Guided decoding for all future steps

### DIFF
--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -206,7 +206,7 @@ class Request:
     def is_grammar_ready(self) -> bool:
         if isinstance(self._grammar, Future):
             return not self._grammar.running() and self._grammar.done()
-        return (self.status == RequestStatus.WAITING
+        return (self.status == RequestStatus.WAITING or self.status == RequestStatus.RUNNING
                 and self._grammar is not None)
 
     @property


### PR DESCRIPTION
Guided decoding for version V1 (related to #12388 ) does not advance the FSM when we use xgrammar with json object as the backed. This then leads to guided decoding being disabled for subsequent steps. The reason for Guided decoding being skipped is because _is_gramma_ready return True only when the request is waiting and not when its running. There is a change needed in in the request.py snippet . So that the _is_grammar_ready is True even when we have the request in the Running stage. This would help update the states and accept tokens here

Had created an issue for it ! 
https://github.com/vllm-project/vllm/issues/13433



